### PR TITLE
Create assertion for toStorageString method

### DIFF
--- a/src/main/java/louie/tasks/Task.java
+++ b/src/main/java/louie/tasks/Task.java
@@ -92,6 +92,7 @@ public abstract class Task {
      * @return a String that shows the name and done status of the task.
      */
     public String toStorageString() {
+        assert !this.name.contains(",") : "name cannot contain commas";
         String doneStr = this.isDone ? "T" : "F";
         String priorityStr;
 


### PR DESCRIPTION
The name of a task can never contain a delimiter since it checks during construction. Lets add an assertion for when the tasks are being stored.